### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/webpack.yml
+++ b/.github/workflows/webpack.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/akabarki76/bug-free-tribble/security/code-scanning/1](https://github.com/akabarki76/bug-free-tribble/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow primarily interacts with repository contents (e.g., checking out code), the `contents: read` permission is sufficient. This ensures that the GITHUB_TOKEN has only the minimal permissions required to complete the tasks in the workflow.

The `permissions` block should be added at the root level of the workflow, so it applies to all jobs unless overridden. This change will limit the permissions of the GITHUB_TOKEN and adhere to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
